### PR TITLE
added CSS to accommodate larger table of contents in the aside section

### DIFF
--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -49,10 +49,9 @@
 .page__aside {
     grid-area: aside;
     color: var(--off-fg);
-    position: fixed;
-    top: 5rem;
-    width: 15rem;
-    margin-left: 50rem;
+    position: sticky;
+    top: 1rem;
+    right: 1rem;
     overflow-y: auto;
     max-height: 95vh;
 }


### PR DESCRIPTION
My table of contents had 15+ entries which resulted in clipping and I was unable to use it. Furthermore having it fixed/sticked to the site while scrolling is helpful to navigate a post/content